### PR TITLE
Earth Armor fix - now correctly removing the armor after DURATION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build.xml
 /.externalToolBuilders/
 /.sonar/
 /.idea/
+/src/main/java/org/*

--- a/src/main/java/net/avatar/realms/spigot/bending/abilities/earth/EarthArmor.java
+++ b/src/main/java/net/avatar/realms/spigot/bending/abilities/earth/EarthArmor.java
@@ -31,7 +31,7 @@ public class EarthArmor extends BendingActiveAbility {
 	public final static String NAME = "EarthArmor";
 	
 	@ConfigurationParameter("Duration")
-	private static long DURATION = 60000;
+	private static long DURATION = 59000;
 
 	@ConfigurationParameter("Strength")
 	private static int STRENGTH = 2;
@@ -63,6 +63,7 @@ public class EarthArmor extends BendingActiveAbility {
 	@SuppressWarnings("deprecation")
 	@Override
 	public boolean swing() {
+
 		//EarthArmor
 		
 		if (this.bender.isOnCooldown(NAME)) {
@@ -301,7 +302,11 @@ public class EarthArmor extends BendingActiveAbility {
 		}
 
 		if (this.formed) {
-			if ((System.currentTimeMillis() > (this.starttime + DURATION)) && !this.complete) {
+
+			long testInt = 0;
+			testInt = this.starttime + DURATION;
+
+			if (System.currentTimeMillis() > testInt && !this.complete) {
 				this.complete = true;
 				removeEffect();
 				return;


### PR DESCRIPTION
Mon tout premier pull request. huhu ^^ 

J'ignore porquoi, mais l'addition de this.starttime + DURATION était traitée comme une concaténation et non comme une addition. Du coup j'ai séparé ça.

Cependant juste cela n'avait pas l'air d'être suffisant.
Du coup suite à des tests, j'ai changé la valeur de DURATION et il semblerait que cela marche correctement avec cette différence. Bizarrement ça marche avec :
DURATION = 3000; (3sec)
DURATION = 30000; (30sec) 
etc...
DURATION = 59000; (59sec)

Mais dès que je mets DURATION = 60000; ça ne marche plus

Du coup voila. Dites moi si cela vous convient.
